### PR TITLE
ignore 404 on delete_document

### DIFF
--- a/app/models/concerns/refinery/elasticsearch/searchable.rb
+++ b/app/models/concerns/refinery/elasticsearch/searchable.rb
@@ -48,7 +48,8 @@ module Refinery
           client.delete({
             index: ::Refinery::Elasticsearch.index_name,
             type:  self.class.document_type,
-            id:    self.id
+            id:    self.id,
+            ignore: 404
           })
           ::Refinery::Elasticsearch.log(:debug, "Deleted document #{self.id}")
         end

--- a/refinerycms-elasticsearch.gemspec
+++ b/refinerycms-elasticsearch.gemspec
@@ -14,11 +14,11 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
 
   # Runtime dependencies
-  s.add_dependency 'refinerycms'
+  s.add_dependency 'refinerycms', '~> 3.0.0'
   s.add_dependency 'patron'
-  s.add_dependency 'elasticsearch',    '~> 1.0'
+  s.add_dependency 'elasticsearch'
   s.add_dependency 'hashie'
 
   # Development dependencies (usually used for testing)
-  s.add_development_dependency 'refinerycms-testing', '~> 2.1.2'
+  s.add_development_dependency 'refinerycms-testing', '~> 3.0.0'
 end


### PR DESCRIPTION
It prevents the raise of errors if current deleted page was not indexed.