### PR TITLE
Remove acts_as_indexed search override of views

### DIFF
--- a/app/views/refinery/acts_as_indexed/admin/_search.html.erb
+++ b/app/views/refinery/acts_as_indexed/admin/_search.html.erb
@@ -1,7 +1,0 @@
-<form method='GET' action='<%= url %>' class='search_form'>
-  <%= text_field :search, nil, :id => 'search', :type => 'search', :name => 'q', :value => params[:q], :title => t('search_input_notice', :scope => 'refinery.admin.search') %>
-  <%= hidden_field :wymeditor, nil, :name => 'wymeditor', :id => nil, :value => true  if params[:wymeditor].presence %>
-  <%= hidden_field :dialog, nil, :name => 'dialog', :id => nil, :value => true if from_dialog? %>
-  <%= hidden_field :callback, nil, :name => 'callback', :id => nil, :value => @callback if @callback.presence %>
-  <%= submit_tag t('button_text', :scope => 'refinery.admin.search'), :name => nil %>
-</form>

--- a/app/views/refinery/acts_as_indexed/admin/_search_header.html.erb
+++ b/app/views/refinery/acts_as_indexed/admin/_search_header.html.erb
@@ -1,4 +1,0 @@
-<% if searching? %>
-  <%= link_to t('cancel_search', :scope => 'refinery.admin.search'), url, :class => "cancel-search" %>
-  <h2><%= t('results_for_html', :scope => 'refinery.admin.search', :query => h(params[:search])).html_safe %></h2>
-<% end %>


### PR DESCRIPTION
Elasticsearch in backend is not yet implemented and it currently breaks Refinery backend search.